### PR TITLE
MSHR & SourceD: add hitLevelL3toL2 function in L3

### DIFF
--- a/src/main/scala/huancun/Common.scala
+++ b/src/main/scala/huancun/Common.scala
@@ -67,7 +67,7 @@ class SourceDReq(implicit p: Parameters) extends InnerTask with HasChannelBits {
   val sinkId = UInt(mshrBits.W)
   val bypassPut = Bool()
   val dirty = Bool()
-  val isHit = Bool()
+  val hitLevelL3toL2 = UInt(2.W)
 }
 
 class SourceAReq(implicit p: Parameters) extends HuanCunBundle {
@@ -115,7 +115,6 @@ class SinkDResp(implicit p: Parameters) extends HuanCunBundle {
   val last = Bool() // last beat
   val denied = Bool()
   val dirty = Bool()
-  // val isHit = Bool()
   val bufIdx = UInt(bufIdxBits.W)
 }
 class SinkEResp(implicit p: Parameters) extends HuanCunBundle {
@@ -154,11 +153,12 @@ class MSHRRequest(implicit p: Parameters) extends HuanCunBundle with HasChannelB
   val alias = aliasBitsOpt.map(_ => UInt(aliasBitsOpt.get.W))
   val preferCache = Bool()
   val dirty = Bool()
-  val isHit = Bool()
   val fromProbeHelper = Bool()
   val fromCmoHelper = Bool()
   val needProbeAckData = if (cacheParams.inclusive) None else Some(Bool())
   val reqSource = UInt(MemReqSource.reqSourceBits.W)
+  val hitLevelL3toL2 = UInt(2.W)
+  
 }
 
 class MSHRStatus(implicit p: Parameters) extends HuanCunBundle with HasChannelBits {

--- a/src/main/scala/huancun/SinkA.scala
+++ b/src/main/scala/huancun/SinkA.scala
@@ -108,7 +108,7 @@ class SinkA(implicit p: Parameters) extends HuanCunModule {
     allocInfo.preferCache := Mux((a.bits.opcode === TLMessages.Get || a.bits.opcode(2,1) === 0.U), true.B, a.bits.user.lift(PreferCacheKey).getOrElse(true.B))
   }
   allocInfo.dirty := false.B // ignored
-  allocInfo.isHit := true.B // ignored
+  allocInfo.hitLevelL3toL2 := 0.U // ignored
   allocInfo.fromProbeHelper := false.B
   allocInfo.fromCmoHelper := false.B
   allocInfo.needProbeAckData.foreach(_ := false.B)

--- a/src/main/scala/huancun/SinkB.scala
+++ b/src/main/scala/huancun/SinkB.scala
@@ -51,7 +51,7 @@ class SinkB(edge: TLEdgeOut)(implicit p: Parameters) extends HuanCunModule {
   io.alloc.bits.alias.foreach(_ := 0.U)
   io.alloc.bits.preferCache := true.B
   io.alloc.bits.dirty := false.B // ignored
-   io.alloc.bits.isHit := true.B // ignored
+  io.alloc.bits.hitLevelL3toL2 := 0.U // ignored
   io.alloc.bits.fromProbeHelper := false.B
   io.alloc.bits.fromCmoHelper := false.B
   io.alloc.bits.needProbeAckData.foreach(_ := io.b.bits.data(0))

--- a/src/main/scala/huancun/Slice.scala
+++ b/src/main/scala/huancun/Slice.scala
@@ -424,6 +424,7 @@ class Slice()(implicit p: Parameters) extends HuanCunModule {
   arbTasks(sourceB.io.task, ms.map(_.io.tasks.source_b), Some("sourceB"), latch=true)
   arbTasks(sourceC.io.task, ms.map(_.io.tasks.source_c), Some("sourceC"), latch=true)
   arbTasks(sourceD.io.task, ms.map(_.io.tasks.source_d), Some("sourceD"), latch=true)
+  dontTouch(sourceD.io.task.bits.hitLevelL3toL2)
   arbTasks(sourceE.io.task, ms.map(_.io.tasks.source_e), Some("sourceE"), latch=true)
   arbTasks(sinkA.io.task, ms.map(_.io.tasks.sink_a), Some("sinkA"), latch=true)
   arbTasks(sinkC.io.task, ms.map(_.io.tasks.sink_c), Some("sinkC"), latch=true)
@@ -635,7 +636,7 @@ class Slice()(implicit p: Parameters) extends HuanCunModule {
     mshrReq.bits.fromCmoHelper := false.B
     mshrReq.bits.bufIdx := DontCare
     mshrReq.bits.dirty := false.B
-    mshrReq.bits.isHit := true.B
+    mshrReq.bits.hitLevelL3toL2 := 0.U
     mshrReq.bits.needProbeAckData.foreach(_ := false.B)
     mshrReq.bits.reqSource := MemReqSource.L2Prefetch.id.U
     pftReq.ready := mshrReq.ready

--- a/src/main/scala/huancun/SourceC.scala
+++ b/src/main/scala/huancun/SourceC.scala
@@ -102,7 +102,7 @@ class SourceC(edge: TLEdgeOut)(implicit p: Parameters) extends HuanCunModule {
   queue.io.enq.bits.user.lift(PreferCacheKey).foreach(_ := true.B)
   queue.io.enq.bits.user.lift(ReqSourceKey).foreach(_ := MemReqSource.NoWhere.id.U)
   queue.io.enq.bits.echo.lift(DirtyKey).foreach(_ := pipeOut.bits.task.dirty)
-  queue.io.enq.bits.user.lift(IsHitKey).foreach(_ := true.B)
+  queue.io.enq.bits.user.lift(HitLevelL3toL2Key).foreach(_ := 0.U)
 
   io.c <> queue.io.deq
 }

--- a/src/main/scala/huancun/SourceD.scala
+++ b/src/main/scala/huancun/SourceD.scala
@@ -161,7 +161,7 @@ class SourceD(implicit p: Parameters) extends HuanCunModule {
   s2_d.bits.data := s1_queue.io.deq.bits.data
   s2_d.bits.corrupt := s2_d.bits.denied
   s2_d.bits.echo.lift(DirtyKey).foreach(_ := s2_req.dirty)
-  s2_d.bits.user.lift(IsHitKey).foreach(_ := s2_req.isHit)
+  s2_d.bits.user.lift(HitLevelL3toL2Key).foreach(_ := s2_req.hitLevelL3toL2)
   dontTouch(s2_d.bits.user)
 
   val s2_can_go = Mux(s2_d.valid, s2_d.ready, s3_ready && (!s2_valid_pb || pb_ready))
@@ -225,7 +225,7 @@ class SourceD(implicit p: Parameters) extends HuanCunModule {
   s3_d.bits.corrupt := s3_req.denied ||
     (s3_req.opcode =/= TLMessages.AccessAck && s3_req.opcode =/= TLMessages.Grant && s3_queue.io.deq.bits.corrupt)
   s3_d.bits.echo.lift(DirtyKey).foreach(_ := s3_req.dirty)
-  s3_d.bits.user.lift(IsHitKey).foreach(_ := s3_req.isHit)
+  s3_d.bits.user.lift(HitLevelL3toL2Key).foreach(_ := s3_req.hitLevelL3toL2)
   dontTouch(s3_d.bits.user)
 
   s3_queue.io.enq.valid := RegNextN(

--- a/src/main/scala/huancun/noninclusive/MSHR.scala
+++ b/src/main/scala/huancun/noninclusive/MSHR.scala
@@ -553,6 +553,16 @@ class MSHR()(implicit p: Parameters) extends BaseMSHR[DirResult, SelfDirWrite, S
   val w_sinkcack = RegInit(true.B)
 
   val acquire_flag = RegInit(false.B)
+  // hold part of s_acquire：
+    // send acquire to memory when receive an acquire from L2
+    // hold until read Directory next time
+  val s_acquire_hold_for_acquire = RegInit(false.B) 
+  // hold part of s_probe：
+    // send probe to another L2 when receive an acquire from L2
+    // hold until read Directory next time
+  val s_probe_hold_for_acquire = RegInit(false.B) 
+
+  // val sourceD_valid_hold = RegInit(false.B)
 
   def reset_all_flags(): Unit = {
     // Default value
@@ -593,10 +603,16 @@ class MSHR()(implicit p: Parameters) extends BaseMSHR[DirResult, SelfDirWrite, S
     nested_c_hit_reg := false.B
     gotDirty := false.B
     acquire_flag := false.B
+    s_acquire_hold_for_acquire := false.B
+    s_probe_hold_for_acquire := false.B
+    // sourceD_valid_hold := false.B
     a_do_release := false.B
     a_do_probe := false.B
   }
   when(!s_acquire) { acquire_flag := acquire_flag | true.B }
+  
+  when(!s_acquire && req_acquire) { s_acquire_hold_for_acquire := s_acquire_hold_for_acquire | true.B }
+  when(!s_probe && req_acquire) { s_probe_hold_for_acquire := s_probe_hold_for_acquire | true.B }
 
   def x_schedule(): Unit = { // TODO
     // Do probe to maintain coherence
@@ -958,6 +974,10 @@ class MSHR()(implicit p: Parameters) extends BaseMSHR[DirResult, SelfDirWrite, S
   io.tasks.prefetch_train.foreach(_.valid := !s_triggerprefetch.get)
   io.tasks.prefetch_resp.foreach(_.valid := !s_prefetchack.get && w_grantfirst)
 
+  // when(io.tasks.source_d.valid){
+    // sourceD_valid_hold := sourceD_valid_hold | true.B
+  // }
+  
   val oa = io.tasks.source_a.bits
   val ob = io.tasks.source_b.bits
   val oc = io.tasks.source_c.bits
@@ -987,6 +1007,9 @@ class MSHR()(implicit p: Parameters) extends BaseMSHR[DirResult, SelfDirWrite, S
   oa.mask := req.mask
   // full overwrite, we can always acquire perm, no need to acquire block
   val acquire_perm_NtoT = req.opcode === AcquirePerm && req.param === NtoT
+
+  // will hit in cork if the acquire from L2 need to acquire downwords L3 and the state transfer is BtoT
+  val acquire_BtoT = req.fromA && req_acquire && req.param === BtoT
 
   val acquire_opcode = if (cacheParams.name == "L2") {
     Mux(req.opcode === AcquirePerm && req.param === BtoT, AcquirePerm, Mux(req.opcode === Hint, AcquireBlock, req.opcode))
@@ -1166,9 +1189,27 @@ class MSHR()(implicit p: Parameters) extends BaseMSHR[DirResult, SelfDirWrite, S
     ),
     false.B
   )
-  od.isHit := self_meta.hit
   od.bufIdx := req.bufIdx
   od.bypassPut := bypassPut_latch
+
+// hitLevelL3toL2 makes sense when sourceD_valid is high
+  val hitFromCork = req.fromA && s_acquire_hold_for_acquire && acquire_BtoT
+  val hitFromMem = req.fromA && s_acquire_hold_for_acquire && !hitFromCork
+  val hitFromAnotherCore = req.fromA && !s_acquire_hold_for_acquire && s_probe_hold_for_acquire
+  val hitFromL3 = req.fromA && req_acquire && !s_acquire_hold_for_acquire && !s_probe_hold_for_acquire && self_meta.hit
+
+    when(hitFromCork){
+      od.hitLevelL3toL2 := 3.U
+    }.elsewhen(hitFromMem){
+      od.hitLevelL3toL2 := 0.U
+    }.elsewhen(hitFromAnotherCore){
+      od.hitLevelL3toL2 := 2.U
+    }.elsewhen(hitFromL3){
+      od.hitLevelL3toL2 := 1.U
+    }.otherwise{
+      od.hitLevelL3toL2 := 0.U
+    }
+
 
   oe.sink := sink
 

--- a/src/main/scala/huancun/noninclusive/ProbeHelper.scala
+++ b/src/main/scala/huancun/noninclusive/ProbeHelper.scala
@@ -46,7 +46,7 @@ class ProbeHelper(entries: Int = 5, enqDelay: Int = 1)(implicit p: Parameters)
   req.alias.foreach(_ := 0.U)
   req.preferCache := true.B
   req.dirty := false.B // ignored
-  req.isHit := true.B // ignored
+  req.hitLevelL3toL2 := 0.U // ignored
   req.needProbeAckData.foreach(_ := false.B)
   req.fromCmoHelper := false.B
   req.reqSource := MemReqSource.NoWhere.id.U

--- a/src/main/scala/huancun/noninclusive/SinkC.scala
+++ b/src/main/scala/huancun/noninclusive/SinkC.scala
@@ -71,7 +71,7 @@ class SinkC(implicit p: Parameters) extends BaseSinkC {
   io.alloc.bits.isBop.foreach(_ := false.B)
   io.alloc.bits.alias.foreach(_ := 0.U)
   io.alloc.bits.preferCache := true.B
-  io.alloc.bits.isHit := true.B
+  io.alloc.bits.hitLevelL3toL2 := 0.U
   io.alloc.bits.dirty := c.bits.echo.lift(DirtyKey).getOrElse(true.B)
   io.alloc.bits.fromProbeHelper := false.B
   io.alloc.bits.fromCmoHelper := false.B

--- a/src/main/scala/huancun/noninclusive/SliceCtrl.scala
+++ b/src/main/scala/huancun/noninclusive/SliceCtrl.scala
@@ -225,7 +225,7 @@ class SliceCtrl()(implicit p: Parameters) extends HuanCunModule {
   io.cmo_req.bits.alias.foreach(_ := false.B)
   io.cmo_req.bits.preferCache := false.B
   io.cmo_req.bits.dirty := false.B
-  io.cmo_req.bits.isHit := true.B
+  io.cmo_req.bits.hitLevelL3toL2 := 0.U
   io.cmo_req.bits.fromProbeHelper := false.B
   io.cmo_req.bits.fromCmoHelper := true.B
   io.cmo_req.bits.needProbeAckData.foreach(_ := false.B)

--- a/src/test/scala/huancun/FakeClient.scala
+++ b/src/test/scala/huancun/FakeClient.scala
@@ -27,7 +27,8 @@ abstract class BaseFakeClient(name: String, nBanks: Int, probe: Boolean = true)(
       minLatency = 1,
       echoFields = cacheParams.echoField,
       requestFields = Seq(PrefetchField(), PreferCacheField(), DirtyField()),
-      responseKeys = cacheParams.respKey
+      // responseKeys = cacheParams.respKey
+      responseKeys = Seq(HitLevelL3toL2Key)
     )
   })
 }

--- a/src/test/scala/huancun/TestTop.scala
+++ b/src/test/scala/huancun/TestTop.scala
@@ -190,7 +190,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
         minLatency = 1,
         echoFields = Seq(DirtyField()),
         requestFields = Seq(PrefetchField(), PreferCacheField(), DirtyField(), AliasField(2)),
-        responseKeys = Seq(IsHitKey)
+        // responseKeys = Seq(HitLevelL3toL2Key)
       )
     ))
     masterNode
@@ -210,7 +210,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
       prefetch = Some(huancun.prefetch.BOPParameters()),
       reqField = Seq(PreferCacheField()),
       echoField = Seq(DirtyField()),
-      respKey = Seq(IsHitKey)
+      respKey = Seq(HitLevelL3toL2Key)
     )
   }))).node)
 
@@ -221,7 +221,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
       inclusive = false,
       clientCaches = Seq(CacheParameters(sets = 32, ways = 8, blockGranularity = 5, name = "L3")),
       echoField = Seq(DirtyField()),
-      respField  = Seq(IsHitField()),
+      respField  = Seq(HitLevelL3toL2Field()),
       simulation = true
     )
   })))
@@ -318,7 +318,7 @@ class TestTop_FullSys()(implicit p: Parameters) extends LazyModule {
       clientCaches = Seq(CacheParameters("dcache", sets = 32, ways = 8, blockGranularity = 5)),
       reqField = Seq(PreferCacheField()),
       echoField = Seq(DirtyField()),
-      respKey = Seq(IsHitKey),
+      respKey = Seq(HitLevelL3toL2Key),
       prefetch = Some(huancun.prefetch.BOPParameters()),
       sramDepthDiv = 2,
       simulation = true


### PR DESCRIPTION
tell L2 where the granted block is from
delete isHit basic function because it is involved in hitLevelL3toL2 function