### PR TITLE
HuanCun: replace `chisel3.experimental.IO` with `chisel3.IO`

### DIFF
--- a/src/main/scala/huancun/HuanCun.scala
+++ b/src/main/scala/huancun/HuanCun.scala
@@ -162,7 +162,7 @@ trait HasHuanCunParameters {
 
 trait DontCareInnerLogic { this: Module =>
   def IO[T <: Data](iodef: T): T = {
-    val p = chisel3.experimental.IO.apply(iodef)
+    val p = chisel3.IO.apply(iodef)
     p <> DontCare
     p
   }


### PR DESCRIPTION
`chisel3.experimental.IO` has been deprecated in chisel 3.6.0 and removed in chisel 5.