### PR TITLE
XSPerfAccumulate: change magicStr

### DIFF
--- a/src/main/scala/huancun/utils/XSPerfAccumulate.scala
+++ b/src/main/scala/huancun/utils/XSPerfAccumulate.scala
@@ -108,7 +108,7 @@ object XSPerfPrint {
     apply(Printable.pack(fmt, data: _*))(ctrlInfo)
 
   def apply(pable: Printable)(ctrlInfo: LogPerfIO): Any = {
-    val commonInfo = p"[PERF ][time=${ctrlInfo.timer}] 9527: "
+    val commonInfo = p"[PERF ][time=${ctrlInfo.timer}] __PERCENTAGE_M__: "
     printf(commonInfo + pable)
   }
 }


### PR DESCRIPTION
The original magic string, 9527, used for "%m" may be too general. I would propose changing it.