### PR TITLE
prefetch: fix tp-meta-req way width

### DIFF
--- a/src/main/scala/huancun/Common.scala
+++ b/src/main/scala/huancun/Common.scala
@@ -241,7 +241,7 @@ class TPmetaReq extends Bundle {
   // FIXME: parameterize the hard code
   val hartid = UInt(4.W) // max 16 harts
   val set = UInt(32.W)
-  val way = UInt(8.W)
+  val way = UInt(4.W)
   val wmode = Bool()
   val rawData = Vec(16, UInt((36-6).W))
 }


### PR DESCRIPTION
Fix the waymask width mismatch to make the compiler happy.

The related PR is the change in SRAMTemplate https://github.com/OpenXiangShan/Utility/pull/50
https://github.com/OpenXiangShan/Utility/pull/50/files#diff-a473eaad7802dde422ddef37a671d197b04af03e62f0c9c37a79d4c2daf24637R63-R64