### PR TITLE
configs: correct MaxHartIdBits

### DIFF
--- a/src/main/scala/huancun/Common.scala
+++ b/src/main/scala/huancun/Common.scala
@@ -237,16 +237,16 @@ class PrefetchRecv extends Bundle {
   val l2_pf_en = Bool()
 }
 
-class TPmetaReq extends Bundle {
+class TPmetaReq(implicit p: Parameters) extends HuanCunBundle {
   // FIXME: parameterize the hard code
-  val hartid = UInt(4.W) // max 16 harts
+  val hartid = UInt(hartIdLen.W)
   val set = UInt(32.W)
   val way = UInt(4.W)
   val wmode = Bool()
   val rawData = Vec(16, UInt((36-6).W))
 }
 
-class TPmetaResp extends Bundle {
-  val hartid = UInt(4.W)
+class TPmetaResp(implicit p: Parameters) extends HuanCunBundle {
+  val hartid = UInt(hartIdLen.W)
   val rawData = Vec(16, UInt((36-6).W))
 }

--- a/src/main/scala/huancun/HuanCun.scala
+++ b/src/main/scala/huancun/HuanCun.scala
@@ -103,6 +103,8 @@ trait HasHuanCunParameters {
 
   lazy val outerSinkBits = edgeOut.bundle.sinkBits
 
+  lazy val hartIdLen: Int = log2Up(cacheParams.hartIds.length)
+
   val block_granularity = if (!cacheParams.inclusive && cacheParams.clientCaches.nonEmpty) {
     cacheParams.clientCaches.head.blockGranularity
   } else setBits

--- a/src/main/scala/huancun/prefetch/TPmeta.scala
+++ b/src/main/scala/huancun/prefetch/TPmeta.scala
@@ -31,7 +31,7 @@ class TPmetaIO(implicit p: Parameters) extends TPmetaBundle {
 
 class metaEntry(implicit p:Parameters) extends TPmetaBundle {
   val rawData = Vec(16, UInt((36-6).W))
-  val hartid = UInt(4.W)
+  val hartid = UInt(hartIdLen.W)
   // TODO: val compressedData = UInt(512.W)
 }
 


### PR DESCRIPTION
Currently, many different lengths of HartId in Xiangshan, making it hard to configure it to scale more than 16 cores since we have set 4bits somewhere. This commit corrects MaxHartIdBits in config and uses MaxHartIDBits where it needs to get this solved.