### PR TITLE
FIX: bufIdx width should increase after #SinkCbufBlocks increase

### DIFF
--- a/src/main/scala/huancun/HuanCun.scala
+++ b/src/main/scala/huancun/HuanCun.scala
@@ -67,9 +67,9 @@ trait HasHuanCunParameters {
     else cacheParams.clientCaches.head.aliasBitsOpt
 
   val bufBlocks = mshrs / 2
-  val bufIdxBits = log2Ceil(bufBlocks)
   val sinkCbufBlocks = mshrsAll // sinkC buffer require more blocks to avoid deadlock
   require(sinkCbufBlocks >= bufBlocks, "sinkCbufBlocks should bigger than bufBlocks")
+  val bufIdxBits = log2Ceil(mshrsAll) // should be MAX{bufBlocks, sinkCBufBlocks}
 
   val alwaysReleaseData = cacheParams.alwaysReleaseData
 


### PR DESCRIPTION
or sinkC bufferVals will be mistakenly cleared, causing system stall