### PR TITLE
MSHR: fix a dual-core bug when ReleaseData nests the Probe

### DIFF
--- a/src/main/scala/huancun/Slice.scala
+++ b/src/main/scala/huancun/Slice.scala
@@ -212,6 +212,8 @@ class Slice()(implicit p: Parameters) extends HuanCunModule {
       mshr.io_c_status.way := c_mshr.io.status.bits.way
       mshr.io_c_status.nestedReleaseData :=
         c_mshr.io.status.valid && non_inclusive(c_mshr).io_is_nestedReleaseData
+      mshr.io_c_status.metaValid := non_inclusive(c_mshr).io_metaValid
+      mshr.io_c_status.reqDirty := non_inclusive(c_mshr).io_reqDirty
       mshr.io_b_status.set := bc_mshr.io.status.bits.set
       mshr.io_b_status.tag := bc_mshr.io.status.bits.tag
       mshr.io_b_status.way := bc_mshr.io.status.bits.way
@@ -231,6 +233,8 @@ class Slice()(implicit p: Parameters) extends HuanCunModule {
       mshr.io_c_status.way := c_mshr.io.status.bits.way
       mshr.io_c_status.nestedReleaseData :=
         c_mshr.io.status.valid && non_inclusive(c_mshr).io_is_nestedReleaseData
+      mshr.io_c_status.metaValid := non_inclusive(c_mshr).io_metaValid
+      mshr.io_c_status.reqDirty := non_inclusive(c_mshr).io_reqDirty
       mshr.io_b_status.set := 0.U
       mshr.io_b_status.tag := 0.U
       mshr.io_b_status.way := 0.U
@@ -246,6 +250,8 @@ class Slice()(implicit p: Parameters) extends HuanCunModule {
       mshr.io_c_status.tag := 0.U
       mshr.io_c_status.way := 0.U
       mshr.io_c_status.nestedReleaseData := false.B
+      mshr.io_c_status.metaValid := false.B
+      mshr.io_c_status.reqDirty := false.B
       mshr.io_b_status.set := 0.U
       mshr.io_b_status.tag := 0.U
       mshr.io_b_status.way := 0.U


### PR DESCRIPTION
Before this commit, an error scenario was discovered during dual-core TL-test: one client L2 requested the T permission for a block, triggering a probe to another L2. At the same time, the other L2 sent a Release request for the same block. L3 would then process the ReleaseData first by saving it in dataStorage, followed by receiving a probeack without data. At this point, L3 would assume the upper-level cache did not have the block, leading to a AcquireBlock request for the data block from memory, resulting in stale data being granted to L2.

This commit fixes the bug by adding conditional constraints to some of the state transitions in L3. Two key signals were added:

* `nestC_save` indicates that an AcquireBlock is nested by a ReleaseData for the same address, and this ReleaseData has saved into L3.

* `nestC_saveDirty` indicates that nestC_save is satisfied and the ReleaseData is a dirty block.