### PR TITLE
fix(TP): fix XS compiling bug in TPmetaReq/Resp

### DIFF
--- a/src/main/scala/huancun/Common.scala
+++ b/src/main/scala/huancun/Common.scala
@@ -237,16 +237,16 @@ class PrefetchRecv extends Bundle {
   val l2_pf_en = Bool()
 }
 
-class TPmetaReq(implicit p: Parameters) extends HuanCunBundle {
-  // FIXME: parameterize the hard code
+class TPmetaReq(hartIdLen: Int, fullAddressBits: Int, offsetBits: Int) extends Bundle {
+  // TODO: rawData's width is determined by L2; when L2's offsetBits change, rawData should change accordingly
   val hartid = UInt(hartIdLen.W)
   val set = UInt(32.W) // determined by TP
   val way = UInt(4.W)
   val wmode = Bool()
-  val rawData = Vec(16, UInt((fullAddressBits - offsetBits).W))
+  val rawData = Vec(log2Floor(512 / (fullAddressBits - offsetBits)), UInt((fullAddressBits - offsetBits).W))
 }
 
-class TPmetaResp(implicit p: Parameters) extends HuanCunBundle {
+class TPmetaResp(hartIdLen: Int, fullAddressBits: Int, offsetBits: Int) extends Bundle {
   val hartid = UInt(hartIdLen.W)
-  val rawData = Vec(16, UInt((fullAddressBits - offsetBits).W))
+  val rawData = Vec(log2Floor(512 / (fullAddressBits - offsetBits)), UInt((fullAddressBits - offsetBits).W))
 }

--- a/src/main/scala/huancun/HuanCun.scala
+++ b/src/main/scala/huancun/HuanCun.scala
@@ -246,7 +246,7 @@ class HuanCun(implicit p: Parameters) extends LazyModule with HasHuanCunParamete
     BundleBridgeNexusNode[DecoupledIO[TPmetaReq]]()
   )
   val tpmeta_send_node = tpmetaOpt.map(_ =>
-    BundleBridgeSource(() => ValidIO(new TPmetaResp))
+    BundleBridgeSource[ValidIO[TPmetaResp]]()
   )
 
   lazy val module = new HuanCunImp(this)
@@ -327,7 +327,7 @@ class HuanCun(implicit p: Parameters) extends LazyModule with HasHuanCunParamete
     wrapper.tpmeta_recv_node match {
       case Some(x) =>
         // tpmeta.get.io.req <> x.in.head._1
-        val arb = Module(new FastArbiter(new TPmetaReq, x.in.size))
+        val arb = Module(new FastArbiter(new TPmetaReq(hartIdLen, wrapper.node.out.head._2.bundle.addressBits, offsetBits), x.in.size))
         for ((arb, req) <- arb.io.in.zip(x.in)) {
           arb <> req._1
         }

--- a/src/main/scala/huancun/prefetch/TPmeta.scala
+++ b/src/main/scala/huancun/prefetch/TPmeta.scala
@@ -25,12 +25,12 @@ import utility._
 
 
 class TPmetaIO(implicit p: Parameters) extends TPmetaBundle {
-  val req = Flipped(DecoupledIO(new TPmetaReq))
-  val resp = ValidIO(new TPmetaResp)
+  val req = Flipped(DecoupledIO(new TPmetaReq(hartIdLen, fullAddressBits, offsetBits)))
+  val resp = ValidIO(new TPmetaResp(hartIdLen, fullAddressBits, offsetBits))
 }
 
 class metaEntry(implicit p:Parameters) extends TPmetaBundle {
-  val rawData = Vec(16, UInt((36-6).W))
+  val rawData = Vec(log2Floor(512 / (fullAddressBits - offsetBits)), UInt((fullAddressBits - offsetBits).W))
   val hartid = UInt(hartIdLen.W)
   // TODO: val compressedData = UInt(512.W)
 }


### PR DESCRIPTION
Bug: TPmetaReq/Resp cannot get fullAddressBits from EdgeIn/OutKey in CoupledL2, since they are defined in HuanCun(Caused by pr #180)

Solution: use certain parameters for  TPmetaReq/Resp