### PR TITLE
fix(ClockGate): avoid unused BlackBox modules

### DIFF
--- a/src/main/scala/huancun/BaseDirectory.scala
+++ b/src/main/scala/huancun/BaseDirectory.scala
@@ -106,9 +106,11 @@ class SubDirectory[T <: Data](
   val resetIdx = RegInit((sets - 1).U)
   val metaArray = Module(new SRAMTemplate(chiselTypeOf(dir_init), sets, ways, singlePort = true, input_clk_div_by_2 = clk_div_by_2))
 
-  val clk_en = RegInit(false.B)
-  clk_en := ~clk_en
-  val masked_clock = ClockGate(false.B, clk_en, clock)
+  val masked_clock = Option.when(clk_div_by_2) {
+    val clk_en = RegInit(false.B)
+    clk_en := ~clk_en
+    ClockGate(false.B, clk_en, clock)
+  }
 
   val tag_wen = io.tag_w.valid
   val dir_wen = io.dir_w.valid
@@ -134,7 +136,7 @@ class SubDirectory[T <: Data](
       UIntToOH(io.tag_w.bits.way)
     )
     if (clk_div_by_2) {
-      eccArray.clock := masked_clock
+      eccArray.clock := masked_clock.get
     }
     eccRead := eccArray.io.r(io.read.fire, io.read.bits.set).resp.data
   } else {
@@ -150,8 +152,8 @@ class SubDirectory[T <: Data](
   tagRead := tagArray.io.r(io.read.fire, io.read.bits.set).resp.data
 
   if (clk_div_by_2) {
-    metaArray.clock := masked_clock
-    tagArray.clock := masked_clock
+    metaArray.clock := masked_clock.get
+    tagArray.clock := masked_clock.get
   }
 
   val reqReg = RegEnable(io.read.bits, io.read.fire)

--- a/src/main/scala/huancun/utils/SRAMWrapper.scala
+++ b/src/main/scala/huancun/utils/SRAMWrapper.scala
@@ -31,11 +31,10 @@ class SRAMWrapper[T <: Data]
       gen, innerSet, 1, singlePort = true, input_clk_div_by_2 = clk_div_by_2
     ))
 
-    val clk_en = RegInit(false.B)
-    clk_en := ~clk_en
-    val masked_clock = ClockGate(false.B, clk_en, clock)
-
     if (clk_div_by_2) {
+      val clk_en = RegInit(false.B)
+      clk_en := ~clk_en
+      val masked_clock = ClockGate(false.B, clk_en, clock)
       sram.clock := masked_clock
     }
     sram.io.r.req.valid := io.r.req.valid && ren


### PR DESCRIPTION
The previous implementation instantiates unused BlackBox modules when clk_div_by_2 is disabled.